### PR TITLE
Us470 to dev - tungsten on UI

### DIFF
--- a/Psyche/Assets/Prefabs/UI.prefab
+++ b/Psyche/Assets/Prefabs/UI.prefab
@@ -313,7 +313,6 @@ GameObject:
   - component: {fileID: 3371999366776974215}
   - component: {fileID: 5486136740920217453}
   - component: {fileID: 8971213152382722960}
-  - component: {fileID: 8758440327323987177}
   m_Layer: 5
   m_Name: Element (4)
   m_TagString: Untagged
@@ -390,7 +389,7 @@ SpriteRenderer:
   m_SortingLayer: 6
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3d75b6fd428fc9748b00f9f66e5578fa, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.19607843}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -400,26 +399,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &8758440327323987177
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 155151453157986170}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd2ae6f3bb942a548b7a61689e141795, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  toolName: 
-  level: 0
-  toolEnabled: 0
-  batteryLevel: 0
-  maxCapacity: 0
-  batteryPercent: 0
-  rate: 0
-  batteryDrained: 0
 --- !u!1 &271368541938500320
 GameObject:
   m_ObjectHideFlags: 0
@@ -1219,7 +1198,6 @@ GameObject:
   - component: {fileID: 5543997178747603917}
   - component: {fileID: 7027701489665506095}
   - component: {fileID: 8332689260407971745}
-  - component: {fileID: 307309582108945483}
   m_Layer: 5
   m_Name: Element (5)
   m_TagString: Untagged
@@ -1296,7 +1274,7 @@ SpriteRenderer:
   m_SortingLayer: 6
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3d75b6fd428fc9748b00f9f66e5578fa, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.19607843}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -1306,26 +1284,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &307309582108945483
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 917831293996480626}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd2ae6f3bb942a548b7a61689e141795, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  toolName: 
-  level: 0
-  toolEnabled: 0
-  batteryLevel: 0
-  maxCapacity: 0
-  batteryPercent: 0
-  rate: 0
-  batteryDrained: 0
 --- !u!1 &928993155388104755
 GameObject:
   m_ObjectHideFlags: 0
@@ -4771,7 +4729,6 @@ GameObject:
   - component: {fileID: 6656764535911270194}
   - component: {fileID: 1213251991204596929}
   - component: {fileID: 6257963918514445753}
-  - component: {fileID: 4505284310850617376}
   m_Layer: 5
   m_Name: Element (6)
   m_TagString: Untagged
@@ -4848,7 +4805,7 @@ SpriteRenderer:
   m_SortingLayer: 6
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3d75b6fd428fc9748b00f9f66e5578fa, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.19607843}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -4858,26 +4815,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &4505284310850617376
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2229381180397392328}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd2ae6f3bb942a548b7a61689e141795, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  toolName: 
-  level: 0
-  toolEnabled: 0
-  batteryLevel: 0
-  maxCapacity: 0
-  batteryPercent: 0
-  rate: 0
-  batteryDrained: 0
 --- !u!1 &2258920317905871370
 GameObject:
   m_ObjectHideFlags: 0
@@ -5727,7 +5664,6 @@ GameObject:
   - component: {fileID: 7390014560138164252}
   - component: {fileID: 6652338209866608041}
   - component: {fileID: 2782967350515348952}
-  - component: {fileID: 3362987285392014663}
   m_Layer: 5
   m_Name: Element (3)
   m_TagString: Untagged
@@ -5804,7 +5740,7 @@ SpriteRenderer:
   m_SortingLayer: 6
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3d75b6fd428fc9748b00f9f66e5578fa, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.19607843}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -5814,26 +5750,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &3362987285392014663
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2601859688418209318}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd2ae6f3bb942a548b7a61689e141795, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  toolName: 
-  level: 0
-  toolEnabled: 0
-  batteryLevel: 0
-  maxCapacity: 0
-  batteryPercent: 0
-  rate: 0
-  batteryDrained: 0
 --- !u!1 &2605753800641985410
 GameObject:
   m_ObjectHideFlags: 0
@@ -8108,7 +8024,6 @@ GameObject:
   - component: {fileID: 2538267930619269995}
   - component: {fileID: 1132243349268681394}
   - component: {fileID: 2759517852222390772}
-  - component: {fileID: 1499707227831679880}
   m_Layer: 5
   m_Name: Element
   m_TagString: Untagged
@@ -8185,7 +8100,7 @@ SpriteRenderer:
   m_SortingLayer: 6
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3d75b6fd428fc9748b00f9f66e5578fa, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.19607843}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -8195,26 +8110,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &1499707227831679880
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3784937036196255433}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd2ae6f3bb942a548b7a61689e141795, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  toolName: 
-  level: 0
-  toolEnabled: 0
-  batteryLevel: 0
-  maxCapacity: 0
-  batteryPercent: 0
-  rate: 0
-  batteryDrained: 0
 --- !u!1 &3825867815347799416
 GameObject:
   m_ObjectHideFlags: 0
@@ -10120,7 +10015,6 @@ GameObject:
   - component: {fileID: 1011380854414156044}
   - component: {fileID: 364824551645068331}
   - component: {fileID: 7622062497504766336}
-  - component: {fileID: 5107992277521826682}
   m_Layer: 5
   m_Name: Element (7)
   m_TagString: Untagged
@@ -10197,7 +10091,7 @@ SpriteRenderer:
   m_SortingLayer: 6
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3d75b6fd428fc9748b00f9f66e5578fa, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.19607843}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -10207,26 +10101,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &5107992277521826682
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4467266398919620425}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd2ae6f3bb942a548b7a61689e141795, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  toolName: 
-  level: 0
-  toolEnabled: 0
-  batteryLevel: 0
-  maxCapacity: 0
-  batteryPercent: 0
-  rate: 0
-  batteryDrained: 0
 --- !u!1 &4533915892084685258
 GameObject:
   m_ObjectHideFlags: 0
@@ -11125,7 +10999,6 @@ GameObject:
   - component: {fileID: 7917496144151226533}
   - component: {fileID: 7682842629008077480}
   - component: {fileID: 1049013582365762751}
-  - component: {fileID: 647969803424017119}
   m_Layer: 5
   m_Name: Element (1)
   m_TagString: Untagged
@@ -11202,7 +11075,7 @@ SpriteRenderer:
   m_SortingLayer: 6
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3d75b6fd428fc9748b00f9f66e5578fa, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.5882353}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.19607843}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -11212,26 +11085,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &647969803424017119
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4921881938827443532}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd2ae6f3bb942a548b7a61689e141795, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  toolName: 
-  level: 0
-  toolEnabled: 0
-  batteryLevel: 0
-  maxCapacity: 0
-  batteryPercent: 0
-  rate: 0
-  batteryDrained: 0
 --- !u!1 &5017585625828560073
 GameObject:
   m_ObjectHideFlags: 0
@@ -12516,14 +12369,15 @@ MonoBehaviour:
   batterySprite2: {fileID: -39812770, guid: 95f5ab7703bd6f349b506610baa6faa9, type: 3}
   batterySprite1: {fileID: 88227712, guid: 95f5ab7703bd6f349b506610baa6faa9, type: 3}
   batterySprite0: {fileID: -797366915, guid: 95f5ab7703bd6f349b506610baa6faa9, type: 3}
-  element1: {fileID: 2759517852222390772}
-  element2: {fileID: 1049013582365762751}
-  element3: {fileID: 2914551492360488031}
-  element4: {fileID: 2782967350515348952}
-  element5: {fileID: 8971213152382722960}
-  element6: {fileID: 8332689260407971745}
-  element7: {fileID: 6257963918514445753}
-  element8: {fileID: 7622062497504766336}
+  elements:
+  - {fileID: 2759517852222390772}
+  - {fileID: 1049013582365762751}
+  - {fileID: 2914551492360488031}
+  - {fileID: 2782967350515348952}
+  - {fileID: 8971213152382722960}
+  - {fileID: 8332689260407971745}
+  - {fileID: 6257963918514445753}
+  - {fileID: 7622062497504766336}
   inventoryMenu: {fileID: 1690373141205758407}
   confirmBoxText: {fileID: 7116520113140859952}
   optionsMenu: {fileID: 5624132768119358631}
@@ -16493,7 +16347,6 @@ GameObject:
   - component: {fileID: 953089026643569838}
   - component: {fileID: 2108609252435073970}
   - component: {fileID: 2914551492360488031}
-  - component: {fileID: 7690069920873850935}
   m_Layer: 5
   m_Name: Element (2)
   m_TagString: Untagged
@@ -16570,7 +16423,7 @@ SpriteRenderer:
   m_SortingLayer: 6
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 3d75b6fd428fc9748b00f9f66e5578fa, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.78431374}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.19607843}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -16580,26 +16433,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &7690069920873850935
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7633471731784414574}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd2ae6f3bb942a548b7a61689e141795, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  toolName: 
-  level: 0
-  toolEnabled: 0
-  batteryLevel: 0
-  maxCapacity: 0
-  batteryPercent: 0
-  rate: 0
-  batteryDrained: 0
 --- !u!1 &7699270111964967587
 GameObject:
   m_ObjectHideFlags: 0
@@ -19741,7 +19574,7 @@ SpriteRenderer:
   m_SortingLayer: 6
   m_SortingOrder: 0
   m_Sprite: {fileID: -5177388603050735206, guid: 8884154dfe85442a3a3578be807dbcdf, type: 3}
-  m_Color: {r: 0.13168074, g: 0.6981132, b: 0.02963687, a: 1}
+  m_Color: {r: 0.10588236, g: 0.39607844, b: 0.0627451, a: 0.7607843}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0

--- a/Psyche/Assets/Scenes/Combo_2.unity
+++ b/Psyche/Assets/Scenes/Combo_2.unity
@@ -62553,6 +62553,63 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1001 &1746570646
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -20.124788
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.678651
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.39315155
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5807336345608628539, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_Name
+      value: Element_Tungsten
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
 --- !u!1 &1752001201
 GameObject:
   m_ObjectHideFlags: 0
@@ -72237,3 +72294,4 @@ SceneRoots:
   - {fileID: 277567257}
   - {fileID: 1982448042}
   - {fileID: 2017298398}
+  - {fileID: 1746570646}

--- a/Psyche/Assets/Scenes/Landing_Scene.unity
+++ b/Psyche/Assets/Scenes/Landing_Scene.unity
@@ -225,6 +225,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6813600720024782082, guid: b0b2d71c51a1ed342930e182e3f1eeaa, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
     - target: {fileID: 8266728179494697823, guid: b0b2d71c51a1ed342930e182e3f1eeaa, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -9537,7 +9541,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 155151453157986170, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
       propertyPath: m_Name
-      value: Element5
+      value: Element (4)
       objectReference: {fileID: 0}
     - target: {fileID: 337239980718798433, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
       propertyPath: m_IsActive
@@ -9555,11 +9559,31 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: b741a41b55dc104439e825cf3512e571, type: 3}
+    - target: {fileID: 1878662079208719805, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -43
+      objectReference: {fileID: 0}
     - target: {fileID: 2345780526257056279, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
       propertyPath: m_text
       value: 'Solar Array
 
 '
+      objectReference: {fileID: 0}
+    - target: {fileID: 4891984978523379572, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
+      propertyPath: m_Color.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4891984978523379572, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
+      propertyPath: m_Color.b
+      value: 0.17254902
+      objectReference: {fileID: 0}
+    - target: {fileID: 4891984978523379572, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
+      propertyPath: m_Color.g
+      value: 0.10980393
+      objectReference: {fileID: 0}
+    - target: {fileID: 4891984978523379572, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
+      propertyPath: m_Color.r
+      value: 0.11764707
       objectReference: {fileID: 0}
     - target: {fileID: 5172690812288988953, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
       propertyPath: m_Camera
@@ -9569,9 +9593,9 @@ PrefabInstance:
       propertyPath: m_Name
       value: UI
       objectReference: {fileID: 0}
-    - target: {fileID: 6257963918514445753, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
-      propertyPath: m_Color.a
-      value: 0.39215687
+    - target: {fileID: 6402019854735247698, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7331055490882894279, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
       propertyPath: m_Pivot.x
@@ -9653,21 +9677,9 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7622062497504766336, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
-      propertyPath: m_Color.a
-      value: 0.39215687
-      objectReference: {fileID: 0}
     - target: {fileID: 7633471731784414574, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
       propertyPath: m_Name
-      value: Element3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8332689260407971745, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
-      propertyPath: m_Color.a
-      value: 0.39215687
-      objectReference: {fileID: 0}
-    - target: {fileID: 8971213152382722960, guid: 0043e28fc164ad04b87c444c3de969ce, type: 3}
-      propertyPath: m_Color.a
-      value: 0.39215687
+      value: Element (2)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -11267,6 +11279,10 @@ PrefabInstance:
     - target: {fileID: 82528849670660265, guid: 82c86cb8a92e160419480666861a14e9, type: 3}
       propertyPath: m_Name
       value: PlayerCharacter
+      objectReference: {fileID: 0}
+    - target: {fileID: 1078862222496993058, guid: 82c86cb8a92e160419480666861a14e9, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3118868635833949731, guid: 82c86cb8a92e160419480666861a14e9, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Psyche/Assets/Scenes/Tool_Comb_1.unity
+++ b/Psyche/Assets/Scenes/Tool_Comb_1.unity
@@ -1445,6 +1445,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 480665665574579492, guid: 85b689aa06b21294697df03e50487c2a, type: 3}
   m_PrefabInstance: {fileID: 1391479472}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &99586806
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -22.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.39315155
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5807336345608628539, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_Name
+      value: Element_Tungsten
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
 --- !u!1 &99879184
 GameObject:
   m_ObjectHideFlags: 0
@@ -75664,3 +75721,4 @@ SceneRoots:
   - {fileID: 1648824086}
   - {fileID: 105108828}
   - {fileID: 1090297382}
+  - {fileID: 99586806}

--- a/Psyche/Assets/Scenes/Tool_Combo_3.unity
+++ b/Psyche/Assets/Scenes/Tool_Combo_3.unity
@@ -180,6 +180,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 19f702046084e434a88c0831d88bd428, type: 3}
+--- !u!1001 &115985542
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.7302182
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.762305
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.39315155
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5807336345608628539, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_Name
+      value: Element_Tungsten
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
 --- !u!1 &181252331
 GameObject:
   m_ObjectHideFlags: 0
@@ -2575,7 +2632,7 @@ MonoBehaviour:
   m_BlendStyleIndex: 0
   m_FalloffIntensity: 0.5
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Intensity: 1
+  m_Intensity: 0
   m_LightVolumeIntensity: 1
   m_LightVolumeIntensityEnabled: 0
   m_ApplyToSortingLayers: 0000000029b0cadac76f616693b48571531254bfcfddb5a575901468
@@ -2786,3 +2843,4 @@ SceneRoots:
   - {fileID: 2098569730}
   - {fileID: 506440534}
   - {fileID: 1662972675}
+  - {fileID: 115985542}

--- a/Psyche/Assets/Scenes/Tool_Intro_GRS.unity
+++ b/Psyche/Assets/Scenes/Tool_Intro_GRS.unity
@@ -550,6 +550,7 @@ Transform:
   - {fileID: 976680709}
   - {fileID: 548252460}
   - {fileID: 63878710}
+  - {fileID: 1277762689}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &278541968 stripped
@@ -4075,6 +4076,68 @@ Transform:
   - {fileID: 1413259936}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1277762688
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 247415702}
+    m_Modifications:
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -22.127552
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.06573343
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.39315155
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5807336345608628539, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_Name
+      value: Element_Tungsten
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+--- !u!4 &1277762689 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+  m_PrefabInstance: {fileID: 1277762688}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1288758552
 GameObject:
   m_ObjectHideFlags: 0

--- a/Psyche/Assets/Scenes/Tool_Intro_Imager.unity
+++ b/Psyche/Assets/Scenes/Tool_Intro_Imager.unity
@@ -16674,6 +16674,63 @@ Transform:
   - {fileID: 120630451}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1482213856
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.6817207
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.1517258
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.39315155
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5807336345608628539, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_Name
+      value: Element_Tungsten
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
 --- !u!1001 &1507882394
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17997,3 +18054,4 @@ SceneRoots:
   - {fileID: 1219571929}
   - {fileID: 1142863406}
   - {fileID: 214349783}
+  - {fileID: 1482213856}

--- a/Psyche/Assets/Scenes/Tool_Intro_Thruster.unity
+++ b/Psyche/Assets/Scenes/Tool_Intro_Thruster.unity
@@ -23225,6 +23225,63 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1001 &612974916
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.21249163
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.3446403
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.39315155
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5807336345608628539, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_Name
+      value: Element_Tungsten
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
 --- !u!1 &621864601
 GameObject:
   m_ObjectHideFlags: 0
@@ -98107,3 +98164,4 @@ SceneRoots:
   - {fileID: 1914191503}
   - {fileID: 1023379206}
   - {fileID: 712761968}
+  - {fileID: 612974916}

--- a/Psyche/Assets/Scenes/Tool_Intro_eMagnet.unity
+++ b/Psyche/Assets/Scenes/Tool_Intro_eMagnet.unity
@@ -344,7 +344,7 @@ MonoBehaviour:
   m_BlendStyleIndex: 0
   m_FalloffIntensity: 0.5
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Intensity: 2
+  m_Intensity: 0
   m_LightVolumeIntensity: 1
   m_LightVolumeIntensityEnabled: 0
   m_ApplyToSortingLayers: 0000000029b0cadac76f616693b48571531254bfcfddb5a575901468
@@ -1162,6 +1162,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6753049333266540965, guid: e741af7aeecf1c0448c6a06b5ba4dae9, type: 3}
   m_PrefabInstance: {fileID: 996644285}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1013744600
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.798571
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.3891096
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.39315155
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042798757603998212, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5807336345608628539, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
+      propertyPath: m_Name
+      value: Element_Tungsten
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 29fff3d73acb5844a88b5433fd3e7fe5, type: 3}
 --- !u!1001 &1018180802
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -21229,3 +21286,4 @@ SceneRoots:
   - {fileID: 14623318}
   - {fileID: 738481783}
   - {fileID: 1243307524}
+  - {fileID: 1013744600}

--- a/Psyche/Assets/Scripts/Controllers/UIController.cs
+++ b/Psyche/Assets/Scripts/Controllers/UIController.cs
@@ -236,8 +236,42 @@ public class UIController : BaseController<UIController>
         }
     }
 
-    private void UpdateElements() {
-        //TODO
+    public void UpdateCapturedTungstens(GameStateManager.Scene currentScene) {
+        // Determine which element to update based on the current scene
+        int elementIndex = -1;
+        switch (currentScene) {
+            case GameStateManager.Scene.Landing_Scene:
+                elementIndex = 0;
+                break;
+            case GameStateManager.Scene.Tool_Intro_Imager:
+                elementIndex = 1;
+                break;
+            case GameStateManager.Scene.Tool_Intro_GRS:
+                elementIndex = 2;
+                break;
+            case GameStateManager.Scene.Tool_Intro_eMagnet:
+                elementIndex = 3;
+                break;
+            case GameStateManager.Scene.Tool_Intro_Thruster:
+                elementIndex = 4;
+                break;
+            case GameStateManager.Scene.Tool_Combo_1:
+                elementIndex = 5;
+                break;
+            case GameStateManager.Scene.Tool_Combo_2:
+                elementIndex = 6;
+                break;
+            case GameStateManager.Scene.Tool_Combo_3:
+                elementIndex = 7;
+                break;
+        }
+
+        // If elementIndex is valid, update the corresponding element's alpha to "unghost"
+        if (elementIndex >= 0 && elementIndex < elements.Length) {
+            Color newColor = elements[elementIndex].color;
+            newColor.a = 1f;
+            elements[elementIndex].color = newColor;
+        }
     }
 
     /// <summary>
@@ -341,14 +375,7 @@ public class UIController : BaseController<UIController>
     public Sprite batterySprite1;
     public Sprite batterySprite0;
 
-    public SpriteRenderer element1;
-    public SpriteRenderer element2;
-    public SpriteRenderer element3;
-    public SpriteRenderer element4;
-    public SpriteRenderer element5;
-    public SpriteRenderer element6;
-    public SpriteRenderer element7;
-    public SpriteRenderer element8;
+    public SpriteRenderer[] elements = new SpriteRenderer[8];
 
     [Header("Inventory Menus")]
     public GameObject inventoryMenu;

--- a/Psyche/Assets/Scripts/GameStates/GameStateManager.cs
+++ b/Psyche/Assets/Scripts/GameStates/GameStateManager.cs
@@ -98,7 +98,8 @@ public class GameStateManager : MonoBehaviour
         Tool_Intro_Thruster,
         Tool_Combo_1,
         Tool_Combo_2,
-        
+        Tool_Combo_3,
+
         // Error state or incorrect value passed
         None,
     }

--- a/Psyche/Assets/Scripts/Player/InventoryManager.cs
+++ b/Psyche/Assets/Scripts/Player/InventoryManager.cs
@@ -244,8 +244,15 @@ public class InventoryManager : MonoBehaviour
         // Split the incoming value from its element name and element ID
         string[] element_set = item.Split(' ');
 
-        //Check if valid name passed and return int
+        // Check if valid name passed and return int
         Element element = MatchElement(element_set[0]);
+        
+        // If the element is tungsten, updates the UI for the element at the current scene
+        if (element == Element.TUNGSTEN) {
+            GameStateManager.Scene currentScene = GameController.Instance.gameStateManager.currentScene;
+            UIController.Instance.UpdateCapturedTungstens(currentScene);
+        }
+
         if (!_elements.ContainsKey(element))
         {
             Debug.LogError($"Incorrect element name passed -- InventoryManager Add: {element}");


### PR DESCRIPTION
Eight tungsten element items are now tracked and displayed on the UI. Each scene has a tungsten element which should be hidden in a way that is not just in plain site. The tungsten elements that get picked up in each scene will un-ghost their respected element on the UI, for example the landing scene will un-ghost the very far left element while tungsten in GRNS scene will un-ghost the third and so forth.

- [x] The code compiles
- [x] The code has been developer-tested
- [x] The script and each function has a description
- [x] The code follows guidelines listed in Quality Control Practices