### PR TITLE
Resolves transition bug due to moving platforms

### DIFF
--- a/Psyche/Assets/Scripts/Moving Objects/MovingPlatform.cs
+++ b/Psyche/Assets/Scripts/Moving Objects/MovingPlatform.cs
@@ -61,5 +61,6 @@ public class MovingPlatform : MonoBehaviour
     private void OnCollisionExit2D(Collision2D collision)
     {
         collision.transform.SetParent(null);
+        DontDestroyOnLoad(collision.gameObject);
     }
 }


### PR DESCRIPTION
Player will now re-appear under DontDestroyOnLoad when they jump off of a moving platform.

- [x] The code compiles
- [x] The code has been developer-tested
- [x] The script and each function has a description
- [x] The code follows guidelines listed in Quality Control Practices
