### PR TITLE
Return to Title error fix

### DIFF
--- a/Psyche/Assets/Scenes/06_Thruster.unity
+++ b/Psyche/Assets/Scenes/06_Thruster.unity
@@ -16074,7 +16074,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}

--- a/Psyche/Assets/Scripts/Controllers/UIController.cs
+++ b/Psyche/Assets/Scripts/Controllers/UIController.cs
@@ -494,21 +494,18 @@ public class UIController : BaseController<UIController>
         }
         ///If Title Screen button opened the Confirmation Box
         else
-            EndGame(false);
-    }
+        {
+            /**
+             * Destroys Player and UI so they do not spawn on the start screen
+             */
+            Destroy(PlayerController.Instance.gameObject);
+            Destroy(gameObject);
+            GameController.Instance.sceneTransitionManager.devControl = true;
+            GameController.Instance.sceneTransitionManager.OnInitiateTransition(
+                GameController.Instance.gameStateManager.MatchScene(GameStateManager.Scene.Title)
+                );
 
-    /// <summary>
-    /// Destroys Player and UI so they do not spawn on the start screen or cutscene
-    /// </summary>
-    /// <param name="playCutscene"></param>
-    public void EndGame(bool playCutscene)
-    {
-        Destroy(PlayerController.Instance.gameObject);
-        Destroy(gameObject);
-        if (playCutscene)
-            UnityEngine.SceneManagement.SceneManager.LoadScene("Outro_Cutscene");
-        else
-            UnityEngine.SceneManagement.SceneManager.LoadScene("Title_Screen");
+        }
     }
 
     //========================================================== Upgrades Menu ==========================================================


### PR DESCRIPTION
Pushed this fix early so playtesters don't encounter the issue. I'm assuming going to the end cutscene no longer uses the EndGame() function in UIController so I reworked the logic and got rid of that function. Someone should probably double check that they can finish the game just in case but worked when I tested it on my end.

- [x] The code compiles
- [x] The code has been developer-tested
- [x] The script and each function has a description
- [x] The code follows guidelines listed in Quality Control Practices