### PR TITLE
US590 to dev (for real this time) - cutscene clean up

### DIFF
--- a/Psyche/Assets/Graphics/UI/player ui/psyche cursor.png.meta
+++ b/Psyche/Assets/Graphics/UI/player ui/psyche cursor.png.meta
@@ -21,7 +21,7 @@ TextureImporter:
     heightScale: 0.25
     normalMapFilter: 0
     flipGreenChannel: 0
-  isReadable: 0
+  isReadable: 1
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
@@ -54,7 +54,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 8
+  textureType: 7
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1

--- a/Psyche/Assets/Scenes/10_Cutscene_Outro.unity
+++ b/Psyche/Assets/Scenes/10_Cutscene_Outro.unity
@@ -747,7 +747,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &384936677
 RectTransform:
   m_ObjectHideFlags: 0
@@ -941,6 +941,7 @@ GameObject:
   - component: {fileID: 1207955235}
   - component: {fileID: 1207955234}
   - component: {fileID: 1207955233}
+  - component: {fileID: 1207955236}
   m_Layer: 5
   m_Name: Outro4
   m_TagString: Untagged
@@ -1007,6 +1008,18 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!225 &1207955236
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1207955232}
+  m_Enabled: 1
+  m_Alpha: 0
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &1513244344
 GameObject:
   m_ObjectHideFlags: 0
@@ -1100,7 +1113,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1843827360
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Psyche/Assets/Scenes/10_Cutscene_Outro.unity
+++ b/Psyche/Assets/Scenes/10_Cutscene_Outro.unity
@@ -247,8 +247,8 @@ MonoBehaviour:
   outro3: {fileID: 287181428}
   outro4: {fileID: 1207955232}
   clickText: {fileID: 214791830}
-  quitButton: {fileID: 384936676}
-  link: {fileID: 1843827359}
+  quitButton: {fileID: 384936678}
+  link: {fileID: 1843827364}
 --- !u!1 &80190068
 GameObject:
   m_ObjectHideFlags: 0
@@ -941,7 +941,6 @@ GameObject:
   - component: {fileID: 1207955235}
   - component: {fileID: 1207955234}
   - component: {fileID: 1207955233}
-  - component: {fileID: 1207955236}
   m_Layer: 5
   m_Name: Outro4
   m_TagString: Untagged
@@ -1008,18 +1007,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!225 &1207955236
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1207955232}
-  m_Enabled: 1
-  m_Alpha: 0
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 0
 --- !u!1 &1513244344
 GameObject:
   m_ObjectHideFlags: 0
@@ -1210,7 +1197,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 1843827362}
   m_OnClick:
     m_PersistentCalls:

--- a/Psyche/Assets/Scripts/UI/IntroController.cs
+++ b/Psyche/Assets/Scripts/UI/IntroController.cs
@@ -11,7 +11,7 @@ public class IntroController : MonoBehaviour
 {
     public GameObject intro1, intro2, intro3, intro4, intro5, intro6, intro7;
     private Image img1, img2, img3, img4, img5, img6, img7;
-
+    private bool IsTransitioning;
     int curScreen = 1;
 
     /// <summary>
@@ -41,6 +41,8 @@ public class IntroController : MonoBehaviour
 
         //fade in the first image
         StartCoroutine(FadeIn(img1));
+
+        IsTransitioning = false;
     }
 
     /// <summary>
@@ -50,44 +52,41 @@ public class IntroController : MonoBehaviour
     {
         if (Input.GetButtonDown("EMagnet"))
         {
-            switch (curScreen)
+            if (!IsTransitioning)
             {
-                case 1:
-                    curScreen++;
-                    StartCoroutine(CrossFade(img1, img2));
-                    break;
+                switch (curScreen)
+                {
+                    case 1:
+                        StartCoroutine(CrossFade(img1, img2));
+                        break;
 
-                case 2:
-                    curScreen++;
-                    StartCoroutine(CrossFade(img2, img3));
-                    break;
+                    case 2:
+                        StartCoroutine(CrossFade(img2, img3));
+                        break;
 
-                case 3:
-                    curScreen++;
-                    StartCoroutine(CrossFade(img3, img4));
-                    break;
-                
-                case 4:
-                    curScreen++;
-                    StartCoroutine(CrossFade(img4, img5));
-                    break;
+                    case 3:
+                        StartCoroutine(CrossFade(img3, img4));
+                        break;
 
-                case 5:
-                    curScreen++;
-                    StartCoroutine(CrossFade(img5, img6));
-                    break;
+                    case 4:
+                        StartCoroutine(CrossFade(img4, img5));
+                        break;
 
-                case 6:
-                    curScreen++;
-                    StartCoroutine(CrossFade(img6, img7));
-                    break;
+                    case 5:
+                        StartCoroutine(CrossFade(img5, img6));
+                        break;
 
-                default:
-                    // Set the value this way so if any changes are made they are accounted for
-                    string scene = GameController.Instance.gameStateManager.MatchScene(GameStateManager.Scene.Landing);
-                    GameController.Instance.sceneTransitionManager.devControl = true;
-                    GameController.Instance.sceneTransitionManager.OnInitiateTransition(scene);
-                    break;
+                    case 6:
+                        StartCoroutine(CrossFade(img6, img7));
+                        break;
+                    default:
+                        // Set the value this way so if any changes are made they are accounted for
+                        string scene = GameController.Instance.gameStateManager.MatchScene(GameStateManager.Scene.Landing);
+                        GameController.Instance.sceneTransitionManager.devControl = true;
+                        GameController.Instance.sceneTransitionManager.OnInitiateTransition(scene);
+                        break;
+                }
+                curScreen++;
             }
         }
     }
@@ -100,6 +99,8 @@ public class IntroController : MonoBehaviour
     /// <returns></returns>
     private IEnumerator CrossFade(Image img1, Image img2)
     {
+        IsTransitioning = true;
+
         //fades out the first image
         img1.CrossFadeAlpha(0, 1.0f, false);
         yield return new WaitForSeconds(1.0f);
@@ -107,6 +108,8 @@ public class IntroController : MonoBehaviour
         //fades in the second image
         img2.CrossFadeAlpha(1, 2.0f, false);
         yield return new WaitForSeconds(2.0f);
+
+        IsTransitioning = false;
     }
 
     /// <summary>

--- a/Psyche/Assets/Scripts/UI/IntroController.cs
+++ b/Psyche/Assets/Scripts/UI/IntroController.cs
@@ -119,7 +119,11 @@ public class IntroController : MonoBehaviour
     /// <returns></returns>
     private IEnumerator FadeIn(Image img)
     {
+        IsTransitioning = true;
+
         img.CrossFadeAlpha(1, 2.0f, false);
         yield return new WaitForSeconds(2.0f);
+
+        IsTransitioning = false;
     }
 }

--- a/Psyche/Assets/Scripts/UI/IntroController.cs
+++ b/Psyche/Assets/Scripts/UI/IntroController.cs
@@ -42,7 +42,7 @@ public class IntroController : MonoBehaviour
         //fade in the first image
         StartCoroutine(FadeIn(img1));
 
-        IsTransitioning = false;
+        IsTransitioning = true;
     }
 
     /// <summary>

--- a/Psyche/Assets/Scripts/UI/OutroController.cs
+++ b/Psyche/Assets/Scripts/UI/OutroController.cs
@@ -10,8 +10,9 @@ using System.Collections;
 public class OutroController : MonoBehaviour {
 
     public GameObject outro1, outro2, outro3, outro4, clickText, quitButton, link;
-    private Image img1, img2, img3, img4;
+    private Image img1, img2, img3;
     private bool IsTransitioning;
+    private CanvasGroup outro4Group;
     int curScreen = 1;
 
     /// <summary>
@@ -25,18 +26,18 @@ public class OutroController : MonoBehaviour {
         img1 = outro1.GetComponentInChildren<Image>();
         img2 = outro2.GetComponentInChildren<Image>();
         img3 = outro3.GetComponentInChildren<Image>();
-        img4 = outro4.GetComponentInChildren<Image>();
 
         //set all their alphas to 0, except img1 (first cs)
         img1.canvasRenderer.SetAlpha(0);
         img2.canvasRenderer.SetAlpha(0);
         img3.canvasRenderer.SetAlpha(0);
-        img4.canvasRenderer.SetAlpha(0);
 
         //fade in the first image
         StartCoroutine(FadeIn(img1));
 
         IsTransitioning = false;
+
+        outro4Group = outro4.GetComponent<CanvasGroup>();
     }
 
     /// <summary>
@@ -59,28 +60,10 @@ public class OutroController : MonoBehaviour {
                         break;
 
                     case 3:
-                        StartCoroutine(CrossFadeLastCS(img3, img4));
+                        StartCoroutine(CrossFadeLastCS(img3));
                         break;
 
                     default:
-                        // in case there's some error in the outro, the last image still shows, and the correct buttons are active
-                        //set all their alphas to 0, except img1 (first cs)
-                        if (img4.canvasRenderer.GetAlpha() == 0)
-                        {
-                            img1.canvasRenderer.SetAlpha(0);
-                            img2.canvasRenderer.SetAlpha(0);
-                            img3.canvasRenderer.SetAlpha(0);
-                            img4.canvasRenderer.SetAlpha(1);
-
-                            //disable the "click to continue" text
-                            clickText.SetActive(false);
-
-                            //enable the quit button
-                            quitButton.SetActive(true);
-
-                            //enable the link
-                            link.SetActive(true);
-                        }
                         break;
                 }
                 curScreen++;
@@ -136,11 +119,15 @@ public class OutroController : MonoBehaviour {
     /// <returns></returns>
     private IEnumerator FadeIn(Image img)
     {
+        IsTransitioning = true;
+
         img.CrossFadeAlpha(1, 2.0f, false);
         yield return new WaitForSeconds(2.0f);
+
+        IsTransitioning = false;
     }
 
-    private IEnumerator CrossFadeLastCS(Image img1, Image img2)
+    private IEnumerator CrossFadeLastCS(Image img1)
     {
         //disable the "click to continue" text
         clickText.SetActive(false);
@@ -149,14 +136,16 @@ public class OutroController : MonoBehaviour {
         img1.CrossFadeAlpha(0, 1.0f, false);
         yield return new WaitForSeconds(1.0f);
 
-        //fades in the second image
-        img2.CrossFadeAlpha(1, 2.0f, false);
-        yield return new WaitForSeconds(1.0f);
 
-        //enable the quit button
-        quitButton.SetActive(true);
-
-        //enable link
-        link.SetActive(true);
+        //fades in the second image, the link, and the quit button
+        CanvasGroup outro4Group = outro4.GetComponent<CanvasGroup>();
+        
+        while (outro4Group.alpha < 1)
+        {
+            outro4Group.alpha += 0.0000002f;
+        }
+        
+        yield return new WaitForSeconds(2.0f);
+        
     }
 }

--- a/Psyche/Assets/Scripts/UI/OutroController.cs
+++ b/Psyche/Assets/Scripts/UI/OutroController.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using System.Collections;
+using TMPro;
 
 /// <summary>
 /// Basic Outro Cutscene that shows an image
@@ -9,16 +10,19 @@ using System.Collections;
 /// Author: jmolive8, blopezro, dnguye99
 public class OutroController : MonoBehaviour {
 
-    public GameObject outro1, outro2, outro3, outro4, clickText, quitButton, link;
-    private Image img1, img2, img3;
+    public GameObject outro1, outro2, outro3, outro4, clickText;
+    public Button quitButton, link;
+    private Image img1, img2, img3, img4, buttonImg, linkImg;
+    private TMP_Text buttonText;
     private bool IsTransitioning;
-    private CanvasGroup outro4Group;
+    private Color buttonColor;
     int curScreen = 1;
 
     /// <summary>
     /// Gets rid of objects not needed anymore
     /// </summary>
     void Awake() {
+        //remove the Player and UI objects so they aren't on screen
         Destroy(GameObject.FindGameObjectWithTag("Player"));
         Destroy(GameObject.FindGameObjectWithTag("UI"));
 
@@ -26,18 +30,34 @@ public class OutroController : MonoBehaviour {
         img1 = outro1.GetComponentInChildren<Image>();
         img2 = outro2.GetComponentInChildren<Image>();
         img3 = outro3.GetComponentInChildren<Image>();
+        img4 = outro4.GetComponentInChildren<Image>();
 
-        //set all their alphas to 0, except img1 (first cs)
+        //get the images/sprites from the buttons
+        buttonImg = quitButton.GetComponent<Image>();
+        buttonText = quitButton.GetComponentInChildren<TMP_Text>();
+        linkImg = link.GetComponent<Image>();
+
+        //save the Quit to Title button color
+        buttonColor = buttonImg.color;
+
+        //then make the button not interactable
+        quitButton.interactable = false;
+
+        //set all the components' alphas to 0, except img1 (first cs)
         img1.canvasRenderer.SetAlpha(0);
         img2.canvasRenderer.SetAlpha(0);
         img3.canvasRenderer.SetAlpha(0);
+        img4.canvasRenderer.SetAlpha(0);
+        linkImg.canvasRenderer.SetAlpha(0);
+        buttonText.canvasRenderer.SetAlpha(0);
+        //the quit button doesn't have an "image", so it has to adjust the color on the "image"
+        buttonImg.color = new Color(buttonText.color.r, buttonText.color.b, buttonText.color.b, 0);
 
         //fade in the first image
         StartCoroutine(FadeIn(img1));
 
-        IsTransitioning = false;
-
-        outro4Group = outro4.GetComponent<CanvasGroup>();
+        //set bool for transitioning
+        IsTransitioning = true;
     }
 
     /// <summary>
@@ -45,34 +65,34 @@ public class OutroController : MonoBehaviour {
     /// </summary>
     void Update()
     {
+        //checks if the player has clicked
         if (Input.GetButtonDown("EMagnet"))
         {
+            //checks if there is a transition between images currently happening
             if (!IsTransitioning)
             {
+                //crossfades if there is no transition occurring
                 switch (curScreen)
                 {
                     case 1:
                         StartCoroutine(CrossFade(img1, img2));
                         break;
-
                     case 2:
                         StartCoroutine(CrossFade(img2, img3));
                         break;
-
                     case 3:
-                        StartCoroutine(CrossFadeLastCS(img3));
+                        StartCoroutine(CrossFadeLastCS(img3, img4));
                         break;
-
                     default:
                         break;
                 }
-                curScreen++;
+                curScreen++; //increment the counter 
             }
         }
     }
 
     /// <summary>
-    /// Opens a link to psyche.asu.edu when the player clicks the link on outro4
+    /// Opens a link to psyche.asu.edu when the player clicks the link on the last scene of the outro
     /// </summary>
     public void OpenLink()
     {
@@ -88,7 +108,6 @@ public class OutroController : MonoBehaviour {
         string scene = GameController.Instance.gameStateManager.MatchScene(GameStateManager.Scene.Title);
         GameController.Instance.sceneTransitionManager.devControl = true;
         GameController.Instance.sceneTransitionManager.OnInitiateTransition(scene);
-        //UnityEngine.SceneManagement.SceneManager.LoadScene("Title_Screen");
     }
 
     /// <summary>
@@ -99,6 +118,7 @@ public class OutroController : MonoBehaviour {
     /// <returns></returns>
     private IEnumerator CrossFade(Image img1, Image img2)
     {
+        //turn on the transition flag
         IsTransitioning = true;
 
         //fades out the first image
@@ -109,6 +129,7 @@ public class OutroController : MonoBehaviour {
         img2.CrossFadeAlpha(1, 2.0f, false);
         yield return new WaitForSeconds(2.0f);
 
+        //turn off the transition flag
         IsTransitioning = false;
     }
 
@@ -119,33 +140,54 @@ public class OutroController : MonoBehaviour {
     /// <returns></returns>
     private IEnumerator FadeIn(Image img)
     {
+        //set the transition flag
         IsTransitioning = true;
 
+        //fade in the image
         img.CrossFadeAlpha(1, 2.0f, false);
         yield return new WaitForSeconds(2.0f);
 
+        //turn off the transition flag
         IsTransitioning = false;
     }
 
-    private IEnumerator CrossFadeLastCS(Image img1)
+    /// <summary>
+    /// Fades out the second to last image in the cutscene, then fades in the
+    /// last image, as well as the buttons
+    /// </summary>
+    /// <param name="img1"></param>
+    /// <param name="img2"></param>
+    /// <returns></returns>
+    private IEnumerator CrossFadeLastCS(Image img1, Image img2)
     {
+        //variables needed to fade in the Quit Button
+        float counter = 0f;
+        float duration = 2.0f;
+
         //disable the "click to continue" text
         clickText.SetActive(false);
 
-        //fades out the first image
+        //fades out the first image (cs3)
         img1.CrossFadeAlpha(0, 1.0f, false);
         yield return new WaitForSeconds(1.0f);
 
-
-        //fades in the second image, the link, and the quit button
-        CanvasGroup outro4Group = outro4.GetComponent<CanvasGroup>();
+        //fades in last cs image and its components
+        img2.CrossFadeAlpha(1, 2.0f, false);
+        linkImg.CrossFadeAlpha(1, 2.0f, false);
+        buttonText.CrossFadeAlpha(1, 2.0f, false);
         
-        while (outro4Group.alpha < 1)
+        //fading in the Quit button by adjusting the alpha value little by little
+        while (counter < duration)
         {
-            outro4Group.alpha += 0.0000002f;
+            counter += Time.deltaTime;
+            float alpha = Mathf.Lerp(0, 1, counter/duration);
+            buttonColor.a = alpha;
+            buttonImg.color = buttonColor;
         }
-        
         yield return new WaitForSeconds(2.0f);
-        
+
+        //set the buttons to interactable once the fading has finished
+        quitButton.interactable = true;
+        link.interactable = true;
     }
 }

--- a/Psyche/Assets/Scripts/UI/OutroController.cs
+++ b/Psyche/Assets/Scripts/UI/OutroController.cs
@@ -11,6 +11,7 @@ public class OutroController : MonoBehaviour {
 
     public GameObject outro1, outro2, outro3, outro4, clickText, quitButton, link;
     private Image img1, img2, img3, img4;
+    private bool IsTransitioning;
     int curScreen = 1;
 
     /// <summary>
@@ -34,6 +35,8 @@ public class OutroController : MonoBehaviour {
 
         //fade in the first image
         StartCoroutine(FadeIn(img1));
+
+        IsTransitioning = false;
     }
 
     /// <summary>
@@ -43,43 +46,44 @@ public class OutroController : MonoBehaviour {
     {
         if (Input.GetButtonDown("EMagnet"))
         {
-            switch (curScreen)
+            if (!IsTransitioning)
             {
-                case 1:
-                    curScreen++;
-                    StartCoroutine(CrossFade(img1, img2));
-                    break;
+                switch (curScreen)
+                {
+                    case 1:
+                        StartCoroutine(CrossFade(img1, img2));
+                        break;
 
-                case 2:
-                    curScreen++;
-                    StartCoroutine(CrossFade(img2, img3));
-                    break;
+                    case 2:
+                        StartCoroutine(CrossFade(img2, img3));
+                        break;
 
-                case 3:
-                    curScreen++;
-                    StartCoroutine(CrossFadeLastCS(img3, img4));
-                    break;
+                    case 3:
+                        StartCoroutine(CrossFadeLastCS(img3, img4));
+                        break;
 
-                default:
-                    // in case there's some error in the outro, the last image still shows, and the correct buttons are active
-                    //set all their alphas to 0, except img1 (first cs)
-                    if (img4.canvasRenderer.GetAlpha() == 0)
-                    {
-                        img1.canvasRenderer.SetAlpha(0);
-                        img2.canvasRenderer.SetAlpha(0);
-                        img3.canvasRenderer.SetAlpha(0);
-                        img4.canvasRenderer.SetAlpha(1);
+                    default:
+                        // in case there's some error in the outro, the last image still shows, and the correct buttons are active
+                        //set all their alphas to 0, except img1 (first cs)
+                        if (img4.canvasRenderer.GetAlpha() == 0)
+                        {
+                            img1.canvasRenderer.SetAlpha(0);
+                            img2.canvasRenderer.SetAlpha(0);
+                            img3.canvasRenderer.SetAlpha(0);
+                            img4.canvasRenderer.SetAlpha(1);
 
-                        //disable the "click to continue" text
-                        clickText.SetActive(false);
+                            //disable the "click to continue" text
+                            clickText.SetActive(false);
 
-                        //enable the quit button
-                        quitButton.SetActive(true);
+                            //enable the quit button
+                            quitButton.SetActive(true);
 
-                        //enable the link
-                        link.SetActive(true);
-                    }
-                    break;
+                            //enable the link
+                            link.SetActive(true);
+                        }
+                        break;
+                }
+                curScreen++;
             }
         }
     }
@@ -112,6 +116,8 @@ public class OutroController : MonoBehaviour {
     /// <returns></returns>
     private IEnumerator CrossFade(Image img1, Image img2)
     {
+        IsTransitioning = true;
+
         //fades out the first image
         img1.CrossFadeAlpha(0, 1.0f, false);
         yield return new WaitForSeconds(1.0f);
@@ -119,6 +125,8 @@ public class OutroController : MonoBehaviour {
         //fades in the second image
         img2.CrossFadeAlpha(1, 2.0f, false);
         yield return new WaitForSeconds(2.0f);
+
+        IsTransitioning = false;
     }
 
     /// <summary>


### PR DESCRIPTION
- Players now have a wait in between cutscene image transitions, so they can't click through it quickly and have them overlap and look weird.
- Outro4 buttons (the Quit to Title button, and the psyche.asu.edu link) now fade in with the rest of the image.
- *Note: IntroController.cs and OutroController.cs currently do not follow the style guidelines, as I have another task to do that in these scripts. So that will get taken care of then.

- [x] Comments and descriptions are comprehensible and add to the maintainability of the code
- [x] Comments are not too verbose or numerous
- [x] Code compiles
- [x] The goal of the US has been fulfilled
- [x] There are no merging conflicts
- [x] The code follows guidelines listed in Quality Control Practices
