### PR TITLE
Resolves issue 259

### DIFF
--- a/Psyche/Assets/Scripts/Level Objects/MovingPlatform.cs
+++ b/Psyche/Assets/Scripts/Level Objects/MovingPlatform.cs
@@ -65,7 +65,10 @@ public class MovingPlatform : MonoBehaviour
     /// <param name="collision"><see cref="Collision2D"/></param>
     private void OnCollisionEnter2D(Collision2D collision)
     {
-        collision.transform.SetParent(transform);
+        if (collision.gameObject.tag.Equals("Player"))
+        {
+            collision.transform.SetParent(transform);
+        }
     }
 
     /// <summary>
@@ -74,7 +77,10 @@ public class MovingPlatform : MonoBehaviour
     /// <param name="collision"><see cref="Collision2D"/></param>
     private void OnCollisionExit2D(Collision2D collision)
     {
-        collision.transform.SetParent(null);
-        DontDestroyOnLoad(collision.gameObject);
+        if (collision.gameObject.tag.Equals("Player"))
+        {
+            collision.transform.SetParent(null);
+            DontDestroyOnLoad(collision.gameObject);
+        }
     }
 }


### PR DESCRIPTION
Resolves the issue of the moving platform breaking game when an object other than the player is left on them.

Consequently, only the player will stay on a moving platform while it moves. Any other object left on a horizontally moving platform will fall off the platforms as the platforms move away from underneath them. I don't think this affects any gameplay or level design just a heads up.

- [x] The code compiles
- [x] The code has been developer-tested
- [x] The script and each function has a description
- [x] The code follows guidelines listed in Quality Control Practices
